### PR TITLE
switch from get to post request to send trusted device 2fa

### DIFF
--- a/endpoint/register/pypush_gsa_icloud.py
+++ b/endpoint/register/pypush_gsa_icloud.py
@@ -246,7 +246,7 @@ def trusted_second_factor(dsid, idms_token):
     headers["security-code"] = code
 
     # Send the 2FA code to Apple
-    resp = requests.get(
+    resp = requests.post(
         "https://gsa.apple.com/grandslam/GsService2/validate",
         headers=headers,
         verify=False,


### PR DESCRIPTION
I think that this line was supposed to be a post request, rather than a get request. In my testing, this allowed Trusted Device 2FA to work properly.