### PR TITLE
Fix reading accessoryStorageKey

### DIFF
--- a/macless_haystack/lib/accessory/accessory_registry.dart
+++ b/macless_haystack/lib/accessory/accessory_registry.dart
@@ -36,7 +36,14 @@ class AccessoryRegistry extends ChangeNotifier {
   Future<void> loadAccessories() async {
     loading = true;
 
-    String? serialized = await _storage.read(key: accessoryStorageKey);
+    String? serialized;
+
+    try {
+      serialized = await _storage.read(key: accessoryStorageKey);
+    } catch (e) {
+      serialized = null;
+    }
+    
     if (serialized != null) {
       List accessoryJson = json.decode(serialized);
       List<Accessory> loadedAccessories =


### PR DESCRIPTION
If you update the Macless Haystack page without adding any accessories, it will stop on the splash screen and return:
```
Uncaught : OperationError: The operation failed for an operation-specific reason [main.dart.js:6832:43](https://dchristl.github.io/macless-haystack/main.dart.js)
    wrapException https://dchristl.github.io/macless-haystack/main.dart.js:6832
    Error__throw https://dchristl.github.io/macless-haystack/main.dart.js:12721
    Error_throwWithStackTrace https://dchristl.github.io/macless-haystack/main.dart.js:13023
    call$0 https://dchristl.github.io/macless-haystack/main.dart.js:77906
    _microtaskLoop https://dchristl.github.io/macless-haystack/main.dart.js:10168
    _startMicrotaskLoop https://dchristl.github.io/macless-haystack/main.dart.js:10174
    call$1 https://dchristl.github.io/macless-haystack/main.dart.js:75124
```
In the console. I fixed it by wrapping ```_storage.read(key: accessoryStorageKey);``` in try/catch. 