### PR TITLE
Fixed Flutter Map not showing tiles and problems with dark theme

### DIFF
--- a/macless_haystack/lib/accessory/accessory_detail.dart
+++ b/macless_haystack/lib/accessory/accessory_detail.dart
@@ -98,7 +98,10 @@ class _AccessoryDetailState extends State<AccessoryDetail> {
                                 }
                               }
                             },
-                            icon: const Icon(Icons.edit),
+                            icon: Icon(
+                              Icons.edit,
+                              color: Theme.of(context).primaryColor,
+                            ),
                           ),
                         ),
                       ),

--- a/macless_haystack/lib/history/accessory_history.dart
+++ b/macless_haystack/lib/history/accessory_history.dart
@@ -121,6 +121,7 @@ class _AccessoryHistoryState extends State<AccessoryHistory> {
                       tileProvider: CancellableNetworkTileProvider(),
                       urlTemplate:
                           'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      userAgentPackageName: 'de.dchristl.headlesshaystack',
                       tileBuilder: (context, child, tile) {
                         var isDark =
                             (Theme.of(context).brightness == Brightness.dark);

--- a/macless_haystack/lib/map/map.dart
+++ b/macless_haystack/lib/map/map.dart
@@ -145,6 +145,7 @@ class _AccessoryMapState extends State<AccessoryMap> {
                   : child;
             },
             urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+            userAgentPackageName: 'de.dchristl.headlesshaystack',
           ),
           MarkerLayer(
             markers: [


### PR DESCRIPTION
This pull request introduces minor UI and configuration updates to improve consistency and functionality across the application. The changes include updating the color of an edit icon to match the app's theme and adding a user agent package name for map tile requests.

### UI Improvements:
* Updated the `Icons.edit` icon in `accessory_detail.dart` to dynamically use the app's primary color, ensuring consistency with the theme. (`macless_haystack/lib/accessory/accessory_detail.dart`, [macless_haystack/lib/accessory/accessory_detail.dartL101-R104](diffhunk://#diff-4cdc605ab25496460b1f889115a968f726388217186f4322dbaa398d2b70bb14L101-R104))

### Configuration Enhancements:
* Added a `userAgentPackageName` for OpenStreetMap tile requests in `accessory_history.dart` to specify the package name for user agent identification. (`macless_haystack/lib/history/accessory_history.dart`, [macless_haystack/lib/history/accessory_history.dartR124](diffhunk://#diff-ce8ac5653be7918e9a4f25257dbedb3f37d8f70531d7bb8e9c721d59be12df10R124))
* Added a `userAgentPackageName` for OpenStreetMap tile requests in `map.dart` for improved request identification. (`macless_haystack/lib/map/map.dart`, [macless_haystack/lib/map/map.dartR148](diffhunk://#diff-37da64af072c18ec8c57080ad4d3abca8ad2c9e71247208d69192de00e853471R148))

Closes:
#207 

(PR description made with copilot :P)